### PR TITLE
Correctly set attributes when moving another file.

### DIFF
--- a/lib/attach/model_extension.rb
+++ b/lib/attach/model_extension.rb
@@ -12,6 +12,8 @@ module Attach
           self.attachments.where(:role => @pending_attachment_deletions).destroy_all
         end
 
+        @replaced_attachment&.destroy
+
         if @pending_attachments
           @pending_attachments.values.each(&:save!)
           @pending_attachments = nil
@@ -141,7 +143,7 @@ module Attach
 
         define_method "#{name}=" do |file|
           if file.is_a?(Attach::Attachment)
-            self.try(name)&.destroy
+            @replaced_attachment = self.try(name)
             attachment = file
             attachment.owner = self
             attachment.role = name

--- a/lib/attach/model_extension.rb
+++ b/lib/attach/model_extension.rb
@@ -141,7 +141,11 @@ module Attach
 
         define_method "#{name}=" do |file|
           if file.is_a?(Attach::Attachment)
+            self.try(name)&.destroy
             attachment = file
+            attachment.owner = self
+            attachment.role = name
+            attachment.processed = false
           elsif file
             attachment = Attachment.new({:owner => self, :role => name}.merge(options))
             case file


### PR DESCRIPTION
This ensures that when an attachment is assigned to another attachment object it will take ownership of it.

**Edit** If an attachment is being replaced, then it's destroyed also.